### PR TITLE
Use crates.io libc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,9 @@ authors = ["David Campbell <dcampbell24@gmail.com>"]
 name = "iup"
 path = "src/iup/lib.rs"
 
+[dependencies]
+libc = "0.1"
+
 [dependencies.iup-sys]
 path = "iup-sys"
 version = "*"

--- a/iup-sys/Cargo.toml
+++ b/iup-sys/Cargo.toml
@@ -9,3 +9,6 @@ links = "IUP"
 [lib]
 name = "iup_sys"
 path = "src/lib.rs"
+
+[dependencies]
+libc = "0.1"

--- a/iup-sys/src/lib.rs
+++ b/iup-sys/src/lib.rs
@@ -14,8 +14,6 @@
 // #include "iupkey.h"
 // #include "iupdef.h"
 
-#![feature(libc)]
-
 extern crate libc;
 
 use libc::{ c_char, c_uchar, c_int, c_float, c_double, c_void };

--- a/src/iup/lib.rs
+++ b/src/iup/lib.rs
@@ -6,8 +6,6 @@
 //! otherwise. Refer to the IUP website for their full documentation.
 //!
 
-#![feature(libc)]
-
 extern crate libc;
 extern crate iup_sys;
 


### PR DESCRIPTION
The `libc` crate built in rust install is under a unstable feature gate which only works on _nightly_ builds.
