### PR TITLE
update iup to current rust

### DIFF
--- a/src/callback/callbacks.rs
+++ b/src/callback/callbacks.rs
@@ -127,7 +127,7 @@ impl_callback! {
         let name = "KILLFOCUS_CB";
         extern fn listener(ih: *mut iup_sys::Ihandle) -> CallbackReturn;
         fn set_killfocus_cb<F: Callback(Self)>(&mut self, cb: F) -> Self;
-        fn remove_killfocus_cb(&mut self) -> Option<Box<_>>;                
+        fn remove_killfocus_cb(&mut self) -> Option<Box<_>>;
     }
 }
 


### PR DESCRIPTION
a breaking (but backwards compatible) change was introduced into rustc. This commit makes sure that iup works now on all rust versions after 1.0

sorry about the whitespace noise
